### PR TITLE
Replace device_state_attributes with extra_state_attributes

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -92,7 +92,7 @@ class SkisporetSensor(Entity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         return {
                 ATTR_DISTANCE: self._distance,


### PR DESCRIPTION
Avoid warnings in Home Assistant log:
`Entity sensor.skisporet_xxxx (<class 'custom_components.skisporet.sensor.SkisporetSensor'>) implements device_state_attributes. Please report it to the custom component author. `
See  https://github.com/home-assistant/core/pull/55734 and https://github.com/home-assistant/core/pull/47304